### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Reporting Security Issues
+
+To report a security issue, please email
+[oss-security@googlegroups.com](mailto:oss-security@googlegroups.com)
+with a description of the issue, the steps you took to create the issue,
+affected versions, and, if known, mitigations for the issue.
+
+Our vulnerability management team will respond within 3 working days of your
+email. If the issue is confirmed as a vulnerability, we will open a
+Security Advisory and acknowledge your contributions as part of it. This project
+follows a 90 day disclosure timeline.


### PR DESCRIPTION
https://github.com/ossf/omega-triage-portal#security hyperlinks to a file that doesn't exist, proposing adding it. Contents copied from https://github.com/ossf/scorecard/blob/main/SECURITY.md

Signed-off-by: Scott Brenner <scott@scottbrenner.me>