### PR TITLE
bump azure-core & .gitignore emacs backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -759,3 +759,6 @@ $RECYCLE.BIN/
 # .pnp.*
 
 # End of https://www.toptal.com/developers/gitignore/api/node,yarn,intellij,pycharm,webstorm,python,django,macos,windows,linux
+
+# Emacs backups
+*~

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.7.2
 astroid==2.15.6
-azure-core==1.26.1
+azure-core==1.28.0
 azure-storage-blob==12.17.0
 bandit==1.7.5
 black==22.10.0


### PR DESCRIPTION
- Had trouble building new triage-portal so needed to switch azure-core version
- Added emacs backups to the .gitignore